### PR TITLE
fix: Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,8 @@
     "babel-plugin"
   ],
   "dependencies": {
-    "@babel/helper-plugin-utils": "workspace:^"
-  },
-  "peerDependencies": {
-    "@babel/core": "^7.0.0-0"
-  },
-  "devDependencies": {
-    "@babel/core": "workspace:^",
-    "@babel/helper-plugin-test-runner": "workspace:^"
+    "@babel/helper-plugin-utils": "^7.14.5",
+    "@babel/core": "^7.16.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Workaround for safari 15 for..in bug",
   "repository": {
     "type": "git",
-    "url": "https://github.com/savrcom/babel-plugin-safari-for-in-workaround",
-    "directory": "."
+    "url": "https://github.com/savrcom/babel-plugin-safari-for-in-workaround"
   },
   "homepage": "https://github.com/savrcom/babel-plugin-safari-for-in-workaround",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Workaround for safari 15 for..in bug",
   "repository": {
     "type": "git",
-    "url": "https://github.com/savrcom/babel-plugin-safari-for-in-workaround"
+    "url": "https://github.com/savrcom/babel-plugin-safari-for-in-workaround",
+    "directory": "."
   },
   "homepage": "https://github.com/savrcom/babel-plugin-safari-for-in-workaround",
   "license": "MIT",


### PR DESCRIPTION
Removed testing dependencies since we are not using them in this
project.

Workspaces syntax causes problems when npm tries to install this
package since it's not part of the official babel mono-repository.
Using version numbers should solve the issue.