### PR TITLE
fix: do not append variable declarators

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,6 @@ module.exports = ({ types: t }) => {
           const i = scope.generateUidIdentifier("i");
           const keys = scope.generateUidIdentifier("keys");
 
-          let array = scope.maybeGenerateMemoised(right, true);
-
           const inits = [
             t.variableDeclarator(keys, t.callExpression(
               t.identifier("Object.keys"),
@@ -21,11 +19,6 @@ module.exports = ({ types: t }) => {
               )),
             t.variableDeclarator(i, t.numericLiteral(0))
           ];
-          if (array) {
-            inits.push(t.variableDeclarator(array, right));
-          } else {
-            array = right;
-          }
 
           const item = t.memberExpression(
             t.cloneNode(keys),


### PR DESCRIPTION
Issue: 
When transforming some javascript using the plugin some of the generated code is running twice.

Solution: 
Remove the appending of variable declarators. From what I can see the only thing this does is to add unused declarations to the for loops, for example:

`<         for (let _keys6 = Object.keys(value), _i6 = 0; _i6 < _keys6.length; _i6++) {`

becomes:

`>         for (let _keys6 = Object.keys(value), _i6 = 0, _value3 = value; _i6 < _keys6.length; _i6++) {`